### PR TITLE
Add some simple integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,7 @@ thiserror = "1.0"
 wolfssl-sys = { git = "https://github.com/expressvpn/wolfssl-sys", features = ["postquantum"] }
 
 [dev-dependencies]
+async-trait = "0.1.73"
 env_logger = "0.10.0"
 test-case = "3.0"
+tokio = { version = "1.31.0", features = ["rt", "net", "macros"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::ffi::c_int;
 use bytes::Bytes;
 use thiserror::Error;
 
+/// The `Result::Ok` for a non-blocking operation.
 #[derive(Debug)]
 pub enum Poll<T> {
     /// Underlying IO operations are still ongoing. No output has been generated
@@ -17,6 +18,7 @@ pub enum Poll<T> {
 }
 
 #[derive(Error, Debug)]
+/// The failure result of an operation.
 pub enum Error {
     /// During secure renegotiation, if application data is found, we must call
     /// `wolfssl_read` to extract the data. If that `wolfssl_read` call fails,
@@ -29,10 +31,12 @@ pub enum Error {
 }
 
 impl Error {
+    /// Construct a fatal error
     pub fn fatal(code: c_int) -> Self {
         Self::Fatal(FatalError::from(code))
     }
 
+    /// Construct an app data error
     pub fn app_data(code: c_int) -> Self {
         Self::AppData(FatalError::from(code))
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,13 +32,8 @@ pub enum Error {
 
 impl Error {
     /// Construct a fatal error
-    pub fn fatal(code: c_int) -> Self {
+    pub(crate) fn fatal(code: c_int) -> Self {
         Self::Fatal(FatalError::from(code))
-    }
-
-    /// Construct an app data error
-    pub fn app_data(code: c_int) -> Self {
-        Self::AppData(FatalError::from(code))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use context::*;
 pub use rng::*;
 pub use ssl::*;
 
-use error::{Error, Result};
+pub use error::{Error, Poll, Result};
 
 use std::ptr::NonNull;
 

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -1,0 +1,321 @@
+use wolfssl::{ContextBuilder, Protocol, RootCertificate, Secret, Session, SessionConfig};
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+use tokio::net::{UnixDatagram, UnixStream};
+
+const CA_CERT: &[u8] = &include!("data/ca_cert_der_2048");
+const SERVER_CERT: &[u8] = &include!("data/server_cert_der_2048");
+const SERVER_KEY: &[u8] = &include!("data/server_key_der_2048");
+
+#[async_trait(?Send)]
+trait SockIO {
+    async fn run_io_loop(&self, who: &'static str, sess: &mut Session);
+}
+
+#[async_trait(?Send)]
+impl SockIO for tokio::net::UnixDatagram {
+    async fn run_io_loop(&self, who: &'static str, sess: &mut Session) {
+        let wr_buf = sess.io_write_out();
+
+        let interest = if wr_buf.is_empty() {
+            println!("[{who}] Polling for READ");
+            tokio::io::Interest::READABLE
+        } else {
+            println!("[{who}] Polling for READ|WRITE");
+            tokio::io::Interest::READABLE | tokio::io::Interest::WRITABLE
+        };
+
+        let readiness = self
+            .ready(interest)
+            .await
+            .expect(&format!("[{who}] Poll for readiness"));
+
+        println!("[{who}] Socket is ready for {readiness:?}");
+        if readiness.is_readable() {
+            let mut rd_buf = BytesMut::zeroed(1900); // TODO: less allocating all the time...
+            match self.try_recv(&mut rd_buf[..]) {
+                Ok(nr) => {
+                    println!(
+                        "[{who}] Received {nr} bytes into {} byte buffer",
+                        rd_buf.len()
+                    );
+                    rd_buf.truncate(nr);
+                    sess.io_read_in(rd_buf.into());
+                }
+                Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
+                    println!("[{who}] Receive would block!");
+                    // ignored
+                }
+                Err(_err) => todo!("[{who}] recv error handling"),
+            }
+        }
+        if readiness.is_writable() {
+            // wr_buf should be non-empty per checks above...
+            match self.try_send(&wr_buf[..]) {
+                Ok(nr) => {
+                    println!("[{who}] Sent {nr} bytes from {} byte buffer", wr_buf.len());
+                    assert!(nr == wr_buf.len(), "cannot handle partial write");
+                }
+                Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
+                    todo!("[{who}] Send would block, need to deal with content of wr_bufm not lose it");
+                }
+                Err(err) => todo!("[{who}] send error handling: {err}"),
+            }
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl SockIO for tokio::net::UnixStream {
+    async fn run_io_loop(&self, who: &'static str, sess: &mut Session) {
+        let wr_buf = sess.io_write_out();
+
+        let interest = if wr_buf.is_empty() {
+            println!("[{who}] Polling for READ");
+            tokio::io::Interest::READABLE
+        } else {
+            println!("[{who}] Polling for READ|WRITE");
+            tokio::io::Interest::READABLE | tokio::io::Interest::WRITABLE
+        };
+
+        let readiness = self
+            .ready(interest)
+            .await
+            .expect(&format!("[{who}] Poll for readiness"));
+
+        println!("[{who}] Socket is ready for {readiness:?}");
+        if readiness.is_readable() {
+            let mut rd_buf = BytesMut::zeroed(1900); // TODO: less allocating all the time...
+            match self.try_read(&mut rd_buf[..]) {
+                Ok(nr) => {
+                    println!(
+                        "[{who}] Received {nr} bytes into {} byte buffer",
+                        rd_buf.len()
+                    );
+                    rd_buf.truncate(nr);
+                    sess.io_read_in(rd_buf.into());
+                }
+                Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
+                    println!("[{who}] Receive would block!");
+                    // ignored
+                }
+                Err(_err) => todo!("[{who}] recv error handling"),
+            }
+        }
+        if readiness.is_writable() {
+            // wr_buf should be non empty by checks above...
+            match self.try_write(&wr_buf[..]) {
+                Ok(nr) => {
+                    println!("[{who}] Sent {nr} bytes from {} byte buffer", wr_buf.len());
+                    assert!(nr == wr_buf.len());
+                }
+                Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
+                    todo!("[{who}] Send would block, need to deal with content of wr_buf");
+                }
+                Err(err) => todo!("[{who}] send error handling: {err}"),
+            }
+        }
+    }
+}
+
+async fn client<S: SockIO>(sock: S, protocol: Protocol) {
+    let ca_cert = RootCertificate::Asn1Buffer(CA_CERT);
+
+    let ctx = ContextBuilder::new(protocol)
+        .expect("[Client] new ContextBuilder")
+        .with_root_certificate(ca_cert)
+        .expect("[Client] add root certificate")
+        .build();
+
+    let session_config = SessionConfig::new().with_dtls_nonblocking(true);
+    let mut session = ctx
+        .new_session(session_config)
+        .expect("[Client] Create Client SSL session");
+
+    println!("[Client] Connecting...");
+    'negotiate: loop {
+        match session.try_negotiate().expect("[Client] try_negotiate") {
+            wolfssl::Poll::Pending => {
+                println!("[Client] Negotiation pending, polling sock");
+                sock.run_io_loop("Client", &mut session).await;
+                println!("[Client] Poll complete");
+            }
+            wolfssl::Poll::Ready(_) => {
+                println!("[Client] Negotiation complete!");
+                break 'negotiate;
+            }
+            wolfssl::Poll::AppData(_b) => todo!("[Client] Handle App Data"),
+        }
+    }
+
+    assert!(session.is_init_finished());
+
+    println!("[Client] Starting ping/pong loop");
+
+    let mut buf = BytesMut::with_capacity(1900);
+
+    for ping in ["Hello", /*"Goodbye",*/ "QUIT"] {
+        println!("[Client] Send {ping}");
+
+        let mut ping: BytesMut = ping.into();
+        let _nr = 'send: loop {
+            match session.try_write(&mut ping).expect("[Client] try_write") {
+                wolfssl::Poll::Pending => {
+                    println!("[Client] Write pending, polling sock");
+                    sock.run_io_loop("Client", &mut session).await;
+                    println!("[Client] Poll complete");
+                }
+                wolfssl::Poll::Ready(nr) => {
+                    println!("[Client] Write {nr} complete!");
+                    break 'send nr;
+                }
+                wolfssl::Poll::AppData(_b) => todo!("[Client] Handle App Data"),
+            }
+        };
+
+        buf.clear();
+
+        let nr = 'recv: loop {
+            match session.try_read(&mut buf).expect("[Client] try_read") {
+                wolfssl::Poll::Pending => {
+                    println!("[Client] Read pending, polling sock");
+                    sock.run_io_loop("Client", &mut session).await;
+                    println!("[Client] Poll complete");
+                }
+                wolfssl::Poll::Ready(nr) => {
+                    println!("[Client] Read {nr} complete!");
+                    break 'recv nr;
+                }
+                wolfssl::Poll::AppData(_b) => todo!("[Client] Handle App Data"),
+            }
+        };
+        let pong = String::from_utf8_lossy(&buf[..nr]);
+        println!("[Client] Got pong: {pong}");
+    }
+
+    println!("[Client] Finished");
+}
+
+async fn server<S: SockIO>(sock: S, protocol: Protocol) {
+    let ca_cert = RootCertificate::Asn1Buffer(CA_CERT);
+    let cert = Secret::Asn1Buffer(SERVER_CERT);
+    let key = Secret::Asn1Buffer(SERVER_KEY);
+
+    let ctx = ContextBuilder::new(protocol)
+        .expect("[Server] new ContextBuilder")
+        .with_root_certificate(ca_cert)
+        .expect("[Server] add root certificate")
+        .with_certificate(cert)
+        .expect("[Server] add certificate")
+        .with_private_key(key)
+        .expect("[Server] add private key")
+        .build();
+
+    let session_config = SessionConfig::new().with_dtls_nonblocking(true);
+    let mut session = ctx
+        .new_session(session_config)
+        .expect("[Server] Create Server SSL session");
+
+    println!("[Server] Connecting...");
+    'negotiate: loop {
+        match session.try_negotiate().expect("[Server] try_negotiate") {
+            wolfssl::Poll::Pending => {
+                println!("[Server] Negotiation pending, polling sock");
+                sock.run_io_loop("Server", &mut session).await;
+                println!("[Server] Poll complete");
+            }
+            wolfssl::Poll::Ready(_) => {
+                println!("[Server] Negotiation complete!");
+                break 'negotiate;
+            }
+            wolfssl::Poll::AppData(_b) => todo!("[Server] Handle App Data"),
+        }
+    }
+
+    assert!(session.is_init_finished());
+
+    let mut buf = BytesMut::with_capacity(1900);
+
+    println!("[Server] Starting ping/pong loop");
+
+    'pingpong: loop {
+        buf.clear();
+        let nr = 'recv: loop {
+            match session.try_read(&mut buf).expect("[Server] try_read") {
+                wolfssl::Poll::Pending => {
+                    println!("[Server] Read pending, polling sock");
+                    sock.run_io_loop("Server", &mut session).await;
+                    println!("[Server] Poll complete");
+                }
+                wolfssl::Poll::Ready(nr) => {
+                    println!("[Server] Read {nr} complete!");
+                    break 'recv nr;
+                }
+                wolfssl::Poll::AppData(_b) => todo!("[Server] Handle App Data"),
+            }
+        };
+        let ping = String::from_utf8_lossy(&buf[..nr]);
+        println!("[Server] Got ping: {ping}");
+
+        // We don't reuse buf since we don't want to mess with truncate and reexpand.
+
+        let mut pong: BytesMut = ping.as_ref().into();
+        let _nr = 'send: loop {
+            match session.try_write(&mut pong).expect("[Server] try_write") {
+                wolfssl::Poll::Pending => {
+                    println!("[Server] Write pending, polling sock");
+                    sock.run_io_loop("Server", &mut session).await;
+                    println!("[Server] Poll complete");
+                }
+                wolfssl::Poll::Ready(nr) => {
+                    println!("[Server] Write {nr} complete!");
+                    break 'send nr;
+                }
+                wolfssl::Poll::AppData(_b) => todo!("[Server] Handle App Data"),
+            }
+        };
+
+        if ping == "QUIT" {
+            break 'pingpong;
+        }
+    }
+
+    println!("[Server] Finished");
+    // After we finish `session.callback_write_buffer` contains the
+    // server's final message to the client, but nothing ever triggers
+    // consuming (i.e. actually sending) that because we've told
+    // WolfSSL we've taken it.
+    //
+    // Run a spurious I/O loop. The correct fix is to not tell WolfSSL
+    // we've sent something we haven't in our callbacks.
+    sock.run_io_loop("Server(EXTRA)", &mut session).await;
+}
+
+#[tokio::test]
+async fn dtls() {
+    use Protocol::*;
+
+    // Communicate over a local datagram socket for simplicity
+    let (client_sock, server_sock) = UnixDatagram::pair().expect("UnixDatagram");
+
+    let client = client(client_sock, DtlsClientV1_2);
+    let server = server(server_sock, DtlsServerV1_2);
+
+    // Note that this runs concurrently but not in parallel
+    tokio::join!(client, server);
+}
+
+#[tokio::test]
+async fn tls() {
+    use Protocol::*;
+
+    // Communicate over a local stream socket for simplicity
+    let (client_sock, server_sock) = UnixStream::pair().expect("UnixStream");
+
+    let client = client(client_sock, TlsClientV1_3);
+    let server = server(server_sock, TlsServerV1_3);
+
+    // Note that this runs concurrently but not in parallel
+    tokio::join!(client, server);
+}


### PR DESCRIPTION
These exercise the public API in a more realistic (but admittedly still quite simplistic) way than the unit tests.

Since they must use the public API we notice that `Poll`, `Error` and `Result` were private which made it hard to consume the API.
