### PR TITLE
Add cargo deny to audit licenses of dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request: null # target every PR
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -31,3 +32,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Lint crate
         run: earthly --ci +lint
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check bans licenses sources

--- a/.github/workflows/nightly-cargo-deny.yaml
+++ b/.github/workflows/nightly-cargo-deny.yaml
@@ -1,0 +1,12 @@
+name: Nightly `cargo deny` checks
+on:
+  schedule:
+    - cron:  '24 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1

--- a/Earthfile
+++ b/Earthfile
@@ -41,3 +41,9 @@ lint:
     FROM +copy-src
     RUN rustup component add clippy
     RUN cargo clippy --all-features --all-targets -- -D warnings
+
+
+check-license:
+    RUN cargo install --locked cargo-deny
+    COPY --dir src tests Cargo.toml Cargo.lock deny.toml ./
+    RUN cargo deny --all-features check bans license sources

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,53 @@
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+severity-threshold = "High"
+
+[licenses]
+default = "deny"
+copyleft = "deny"
+unlicensed = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Unicode-DFS-2016",
+    "BSD-3-Clause",
+    "ISC",
+]
+allow-osi-fsf-free = "neither"
+confidence-threshold = 0.8
+exceptions = [
+    { name = "wolfssl", allow = ["GPL-2.0"], version = "*" },
+    { name = "wolfssl-sys", allow = ["GPL-2.0"], version = "*" },
+]
+
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+  "https://github.com/open-quantum-safe/liboqs-rust",
+  "https://github.com/expressvpn/wolfssl-sys",
+]


### PR DESCRIPTION
**Changes:**
- Add deny.toml which `cargo-deny` uses to check license
- Add earthly target `check-license` for checking licenses
- Update github actions to run this target on all PRs