### PR TITLE
Enable clippy undocumented_unsafe_blocks lint

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::undocumented_unsafe_blocks)]
-
 use crate::{
     callback::IOCallbacks,
     error::{Error, Result},
@@ -37,6 +35,10 @@ impl ContextBuilder {
             .into_method_ptr()
             .ok_or(NewContextBuilderError::MethodFailed)?;
 
+        // SAFETY: [`wolfSSL_CTX_new`][0] is documented to get pointer to a valid `WOLFSSL_METHOD` structure which is created using one of the `wolfSSLvXX_XXXX_method()`.
+        // `Protocol::into_method_ptr` function returns a pointer `wolfSSLvXX_XXXX_method()`
+        //
+        // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Setup.html#function-wolfssl_ctx_new
         let ctx = unsafe { wolfssl_sys::wolfSSL_CTX_new(method_fn.as_ptr()) };
         let ctx = NonNull::new(ctx).ok_or(NewContextBuilderError::CreateFailed)?;
 
@@ -54,6 +56,12 @@ impl ContextBuilder {
         };
 
         let result = match root {
+            // SAFETY: [`wolfSSL_CTX_load_verify_buffer`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+            // The pointer given as the `in` argument must point to a region of `sz` bytes.
+            // The values passed here are valid since they are derived from the same byte slice.
+            //
+            // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_load_verify_buffer
+            // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gaa5a28f0ac25d9abeb72fcee81bbf647b
             RootCertificate::Asn1Buffer(buf) => unsafe {
                 wolfSSL_CTX_load_verify_buffer(
                     self.ctx.as_ptr(),
@@ -62,6 +70,12 @@ impl ContextBuilder {
                     WOLFSSL_FILETYPE_ASN1,
                 )
             },
+            // SAFETY: [`wolfSSL_CTX_load_verify_buffer`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+            // The pointer given as the `in` argument must point to a region of `sz` bytes.
+            // The values passed here are valid since they are derived from the same byte slice.
+            //
+            // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_load_verify_buffer
+            // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gaa5a28f0ac25d9abeb72fcee81bbf647b
             RootCertificate::PemBuffer(buf) => unsafe {
                 wolfSSL_CTX_load_verify_buffer(
                     self.ctx.as_ptr(),
@@ -78,6 +92,12 @@ impl ContextBuilder {
                 let path = std::ffi::CString::new(path)
                     .or(Err(Error::fatal(wolfssl_sys::WOLFSSL_BAD_PATH)))?;
                 if is_dir {
+                    // SAFETY: [`wolfSSL_CTX_load_verify_locations`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+                    // If not NULL, then the pointer passed as the path argument must be a valid NULL-terminated C-style string,
+                    // which is guaranteed by the use of `std::ffi::CString::as_c_str()` here.
+                    //
+                    // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_load_verify_locations
+                    // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gaf592c652b5d7a599ee511a394dfc488e
                     unsafe {
                         wolfSSL_CTX_load_verify_locations(
                             self.ctx.as_ptr(),
@@ -86,6 +106,12 @@ impl ContextBuilder {
                         )
                     }
                 } else {
+                    // SAFETY: [`wolfSSL_CTX_load_verify_locations`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+                    // If not NULL, then the pointer passed as the path argument must be a valid NULL-terminated C-style string,
+                    // which is guaranteed by the use of `std::ffi::CString::as_c_str()` here.
+                    //
+                    // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_load_verify_locations
+                    // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gaf592c652b5d7a599ee511a394dfc488e
                     unsafe {
                         wolfSSL_CTX_load_verify_locations(
                             self.ctx.as_ptr(),
@@ -111,6 +137,12 @@ impl ContextBuilder {
         let cipher_list = std::ffi::CString::new(cipher_list)
             .or(Err(Error::fatal(wolfssl_sys::WOLFSSL_FAILURE)))?;
 
+        // SAFETY: [`wolfSSL_CTX_set_cipher_list`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()` and
+        // `list` parameter which should be a null terminated C string pointer which is guaranteed by
+        // the use of `std::ffi::CString::as_c_str()` here.
+        //
+        // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/ssl_8h.html#function-wolfssl_ctx_set_cipher_list
+        // [1]: https://www.wolfssl.com/doxygen/group__Setup.html#gafa55814f56bd7a36f4035d71b2b31832
         let result = unsafe {
             wolfssl_sys::wolfSSL_CTX_set_cipher_list(
                 self.ctx.as_ptr(),
@@ -136,6 +168,12 @@ impl ContextBuilder {
         };
 
         let result = match secret {
+            // SAFETY: [`wolfSSL_CTX_use_certificate_buffer`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+            // The pointer given as the `in` argument must point to a region of `sz` bytes.
+            // The values passed here are valid since they are derived from the same byte slice.
+            //
+            // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_certificate_buffer
+            // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gae424b3a63756ab805de5c43b67f4df4f
             Secret::Asn1Buffer(buf) => unsafe {
                 wolfSSL_CTX_use_certificate_buffer(
                     self.ctx.as_ptr(),
@@ -144,18 +182,32 @@ impl ContextBuilder {
                     WOLFSSL_FILETYPE_ASN1,
                 )
             },
-            Secret::Asn1File(path) => unsafe {
+            Secret::Asn1File(path) => {
                 let path = path
                     .to_str()
                     .ok_or(Error::fatal(wolfssl_sys::BAD_PATH_ERROR))?;
                 let file = std::ffi::CString::new(path)
                     .or(Err(Error::fatal(wolfssl_sys::BAD_PATH_ERROR)))?;
-                wolfSSL_CTX_use_certificate_file(
-                    self.ctx.as_ptr(),
-                    file.as_c_str().as_ptr(),
-                    WOLFSSL_FILETYPE_ASN1,
-                )
-            },
+                // SAFETY: [`wolfSSL_CTX_use_certificate_file`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+                // The pointer passed as the path argument must be a valid NULL-terminated C-style string,
+                // which is guaranteed by the use of `std::ffi::CString::as_c_str()` here.
+                //
+                // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_certificate_file
+                // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#ga5a31292b75b4caa4462a3305d2615beb
+                unsafe {
+                    wolfSSL_CTX_use_certificate_file(
+                        self.ctx.as_ptr(),
+                        file.as_c_str().as_ptr(),
+                        WOLFSSL_FILETYPE_ASN1,
+                    )
+                }
+            }
+            // SAFETY: [`wolfSSL_CTX_use_certificate_buffer`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+            // The pointer given as the `in` argument must point to a region of `sz` bytes.
+            // The values passed here are valid since they are derived from the same byte slice.
+            //
+            // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_certificate_buffer
+            // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gae424b3a63756ab805de5c43b67f4df4f
             Secret::PemBuffer(buf) => unsafe {
                 wolfSSL_CTX_use_certificate_buffer(
                     self.ctx.as_ptr(),
@@ -164,18 +216,26 @@ impl ContextBuilder {
                     WOLFSSL_FILETYPE_PEM,
                 )
             },
-            Secret::PemFile(path) => unsafe {
+            Secret::PemFile(path) => {
                 let path = path
                     .to_str()
                     .ok_or(Error::fatal(wolfssl_sys::BAD_PATH_ERROR))?;
                 let file = std::ffi::CString::new(path)
                     .or(Err(Error::fatal(wolfssl_sys::BAD_PATH_ERROR)))?;
-                wolfSSL_CTX_use_certificate_file(
-                    self.ctx.as_ptr(),
-                    file.as_c_str().as_ptr(),
-                    WOLFSSL_FILETYPE_PEM,
-                )
-            },
+                // SAFETY: [`wolfSSL_CTX_use_certificate_file`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+                // The pointer passed as the path argument must be a valid NULL-terminated C-style string,
+                // which is guaranteed by the use of `std::ffi::CString::as_c_str()` here.
+                //
+                // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_certificate_file
+                // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#ga5a31292b75b4caa4462a3305d2615beb
+                unsafe {
+                    wolfSSL_CTX_use_certificate_file(
+                        self.ctx.as_ptr(),
+                        file.as_c_str().as_ptr(),
+                        WOLFSSL_FILETYPE_PEM,
+                    )
+                }
+            }
         };
 
         if result == wolfssl_sys::WOLFSSL_SUCCESS {
@@ -196,6 +256,12 @@ impl ContextBuilder {
         };
 
         let result = match secret {
+            // SAFETY: [`wolfSSL_CTX_use_PrivateKey_buffer`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+            // The pointer given as the `in` argument must point to a region of `sz` bytes.
+            // The values passed here are valid since they are derived from the same byte slice.
+            //
+            // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_privatekey_buffer
+            // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gaf88bd3ade7faefb028679f48ef64a237
             Secret::Asn1Buffer(buf) => unsafe {
                 wolfSSL_CTX_use_PrivateKey_buffer(
                     self.ctx.as_ptr(),
@@ -204,18 +270,32 @@ impl ContextBuilder {
                     WOLFSSL_FILETYPE_ASN1,
                 )
             },
-            Secret::Asn1File(path) => unsafe {
+            Secret::Asn1File(path) => {
                 let path = path
                     .to_str()
                     .ok_or(Error::fatal(wolfssl_sys::BAD_PATH_ERROR))?;
                 let file = std::ffi::CString::new(path)
                     .or(Err(Error::fatal(wolfssl_sys::BAD_PATH_ERROR)))?;
-                wolfSSL_CTX_use_PrivateKey_file(
-                    self.ctx.as_ptr(),
-                    file.as_c_str().as_ptr(),
-                    WOLFSSL_FILETYPE_ASN1,
-                )
-            },
+                // SAFETY: [`wolfSSL_CTX_use_PrivateKey_file`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+                // The pointer passed as the path argument must be a valid NULL-terminated C-style string,
+                // which is guaranteed by the use of `std::ffi::CString::as_c_str()` here.
+                //
+                // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_privatekey_file
+                // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gab80ef18b3232ebd19acab106b52feeb0
+                unsafe {
+                    wolfSSL_CTX_use_PrivateKey_file(
+                        self.ctx.as_ptr(),
+                        file.as_c_str().as_ptr(),
+                        WOLFSSL_FILETYPE_ASN1,
+                    )
+                }
+            }
+            // SAFETY: [`wolfSSL_CTX_use_PrivateKey_buffer`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+            // The pointer given as the `in` argument must point to a region of `sz` bytes.
+            // The values passed here are valid since they are derived from the same byte slice.
+            //
+            // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_privatekey_buffer
+            // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gaf88bd3ade7faefb028679f48ef64a237
             Secret::PemBuffer(buf) => unsafe {
                 wolfSSL_CTX_use_PrivateKey_buffer(
                     self.ctx.as_ptr(),
@@ -224,18 +304,26 @@ impl ContextBuilder {
                     WOLFSSL_FILETYPE_PEM,
                 )
             },
-            Secret::PemFile(path) => unsafe {
+            Secret::PemFile(path) => {
                 let path = path
                     .to_str()
                     .ok_or(Error::fatal(wolfssl_sys::BAD_PATH_ERROR))?;
                 let file = std::ffi::CString::new(path)
                     .or(Err(Error::fatal(wolfssl_sys::BAD_PATH_ERROR)))?;
-                wolfSSL_CTX_use_PrivateKey_file(
-                    self.ctx.as_ptr(),
-                    file.as_c_str().as_ptr(),
-                    WOLFSSL_FILETYPE_PEM,
-                )
-            },
+                // SAFETY: [`wolfSSL_CTX_use_PrivateKey_file`][0] ([also][1]) requires a valid `ctx` pointer from `wolfSSL_CTX_new()`.
+                // The pointer passed as the path argument must be a valid NULL-terminated C-style string,
+                // which is guaranteed by the use of `std::ffi::CString::as_c_str()` here.
+                //
+                // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_privatekey_file
+                // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gab80ef18b3232ebd19acab106b52feeb0
+                unsafe {
+                    wolfSSL_CTX_use_PrivateKey_file(
+                        self.ctx.as_ptr(),
+                        file.as_c_str().as_ptr(),
+                        WOLFSSL_FILETYPE_PEM,
+                    )
+                }
+            }
         };
 
         if result == wolfssl_sys::WOLFSSL_SUCCESS {
@@ -247,8 +335,10 @@ impl ContextBuilder {
 
     /// Wraps `wolfSSL_CTX_UseSecureRenegotiation`
     ///
-    // NOTE (pangt): I can't seem to find documentation online for this.
+    /// NOTE: No official documentation available for this api from wolfssl
     pub fn with_secure_renegotiation(self) -> Result<Self> {
+        // SAFETY: [`wolfSSL_CTX_UseSecureRenegotiation`][1] does not have proper documentation.
+        // Based on the implementation, the only requirement is the context which is passed to this api has to be a valid `WOLFSSL_CTX`
         let result = unsafe { wolfssl_sys::wolfSSL_CTX_UseSecureRenegotiation(self.ctx.as_ptr()) };
         if result == wolfssl_sys::WOLFSSL_SUCCESS {
             Ok(self)
@@ -346,6 +436,14 @@ impl Drop for Context {
     ///
     /// [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Setup.html#function-wolfssl_ctx_free
     fn drop(&mut self) {
+        // SAFETY: [`wolfSSL_CTX_free`][0] ([also][1]) takes pointer to `WOLFSSL_CTX` and frees it if the reference count becomes 0.
+        // Documentation is not clear about when this reference count will be incremented. From implementation, it is
+        // incremented in [`wolfSSL_set_SSL_CTX`][2] and [`wolfSSL_CTX_up_ref`][3], and we dont use these apis
+        //
+        // [0]: https://www.wolfssl.com/doxygen/group__Setup.html#gabe86939065276c9271a17d799860535d
+        // [1]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Setup.html#function-wolfssl_ctx_free
+        // [2]: https://github.com/wolfSSL/wolfssl/blob/v5.6.3-stable/src/ssl.c#L31235
+        // [3]: https://github.com/wolfSSL/wolfssl/blob/v5.6.3-stable/src/ssl.c#L1357
         unsafe { wolfssl_sys::wolfSSL_CTX_free(self.ctx.as_ptr()) }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 use crate::{
     callback::IOCallbacks,
     error::{Error, Result},

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::undocumented_unsafe_blocks)]
 use std::ffi::c_int;
 
 use bytes::Bytes;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::undocumented_unsafe_blocks)]
 use std::ffi::c_int;
 
 use bytes::Bytes;
@@ -95,6 +94,16 @@ pub type Result<T> = std::result::Result<T, Error>;
 // `wolfSSL_get_error`, which returns a `c_int`
 fn wolf_error_string(raw_err: std::ffi::c_ulong) -> String {
     let mut buffer = vec![0u8; wolfssl_sys::WOLFSSL_MAX_ERROR_SZ as usize];
+
+    // SAFETY:
+    // [`wolfSSL_ERR_error_string()`][0] ([also][1]) is documented to store at most `WOLFSSL_MAX_ERROR_SZ` bytes,
+    // so `buffer` is appropriately sized.
+    // Note that `wolfSSL_ERR_error_string()` is documented to use a static buffer (shared between threads,
+    // and thus non-reentrant) on failure, however it only does so if no buffer is provided as an argument.
+    // Since we provide a buffer we assume the static buffer can never be used in practice.
+    //
+    // [0]: https://www.wolfssl.com/doxygen/group__Debug.html#ga91d8474ba8abcf3fe594928056834993
+    // [1]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Debug.html#function-wolfssl_err_error_string
     unsafe {
         wolfssl_sys::wolfSSL_ERR_error_string(
             raw_err,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! The `wolfssl` crate is designed to be a Rust layer built on top of
 //! the `wolfssl-sys` crate (a C passthrough crate).
 
+#![warn(clippy::undocumented_unsafe_blocks)]
 #![warn(missing_docs)]
 
 mod callback;
@@ -37,6 +38,7 @@ const TLS_MAX_RECORD_SIZE: usize = 2usize.pow(14) + 1;
 ///
 /// [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__TLS.html#function-wolfssl_init
 pub fn wolf_init() -> Result<()> {
+    #[allow(clippy::undocumented_unsafe_blocks)]
     match unsafe { wolfssl_sys::wolfSSL_Init() } {
         wolfssl_sys::WOLFSSL_SUCCESS => Ok(()),
         e => Err(Error::fatal(e)),
@@ -47,6 +49,7 @@ pub fn wolf_init() -> Result<()> {
 ///
 /// [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__TLS.html#function-wolfssl_cleanup
 pub fn wolf_cleanup() -> Result<()> {
+    #[allow(clippy::undocumented_unsafe_blocks)]
     match unsafe { wolfssl_sys::wolfSSL_Cleanup() } {
         wolfssl_sys::WOLFSSL_SUCCESS => Ok(()),
         e => Err(Error::fatal(e)),
@@ -60,6 +63,7 @@ pub fn wolf_cleanup() -> Result<()> {
 #[cfg(feature = "debug")]
 pub fn enable_debugging(on: bool) {
     if on {
+        #[allow(clippy::undocumented_unsafe_blocks)]
         match unsafe { wolfssl_sys::wolfSSL_Debugging_ON() } {
             0 => {}
             // This wrapper function is only enabled if we built wolfssl-sys with debugging on.
@@ -69,7 +73,10 @@ pub fn enable_debugging(on: bool) {
             e => unreachable!("{e:?}"),
         }
     } else {
-        unsafe { wolfssl_sys::wolfSSL_Debugging_OFF() }
+        #[allow(clippy::undocumented_unsafe_blocks)]
+        unsafe {
+            wolfssl_sys::wolfSSL_Debugging_OFF()
+        }
     }
 }
 
@@ -102,6 +109,7 @@ impl Protocol {
     /// Converts a [`Self`] into a [`wolfssl_sys::WOLFSSL_METHOD`]
     /// compatible with [`wolfssl_sys::wolfSSL_CTX_new`]
     pub fn into_method_ptr(self) -> Option<NonNull<wolfssl_sys::WOLFSSL_METHOD>> {
+        #[allow(clippy::undocumented_unsafe_blocks)]
         let ptr = match self {
             Self::DtlsClient => unsafe { wolfssl_sys::wolfDTLS_client_method() },
             Self::DtlsClientV1_2 => unsafe { wolfssl_sys::wolfDTLSv1_2_client_method() },

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::undocumented_unsafe_blocks)]
 use crate::error::{Error, Result};
 
 /// Provides a way to extract random values from WolfSSL.
@@ -8,8 +7,19 @@ impl Random {
     /// Initializes a [`Random`] object.
     pub fn new() -> Result<Random> {
         let mut rng = std::mem::MaybeUninit::<wolfssl_sys::WC_RNG>::uninit();
+        // SAFETY:
+        // [`wc_InitRng()`][0] ([also][1]) is documented to receive [`WC_RNG`] as input to initialise seed and key cipher.
+        // The corresponding memory is deallocated, when dropping this structure
+        //
+        // [0]: https://www.wolfssl.com/doxygen/group__Random.html#ga1a87307fac65d3c2a47ffb743020f83c
+        // [1]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Random.html#function-wc_initrng
         match unsafe { wolfssl_sys::wc_InitRng(rng.as_mut_ptr()) } {
             0 => {
+                // SAFETY:
+                // Based on the documentation from [`wc_InitRng()`][0], `rng` will be initialised successfully
+                // if the return code is `0`. So can safely call `assume_init` here
+                //
+                // [0]: https://www.wolfssl.com/doxygen/group__Random.html#ga1a87307fac65d3c2a47ffb743020f83c
                 let rng = unsafe { rng.assume_init() };
                 Ok(Random(rng))
             }
@@ -20,6 +30,12 @@ impl Random {
     /// Generates a random u64. Advances the internal state of the RNG.
     pub fn random_u64(&mut self) -> Result<u64> {
         let mut buf = [0u8; 8];
+        // SAFETY:
+        // The following invariants required by [`wc_RNG_GenerateBlock()`][0] is satisfied:
+        //      - first argument `&rng` is mutable reference to properly initialised random number generator
+        //      - second argment has valid mutable buffer with proper size corresponding to the size `sz`
+        //
+        // [0]: https://www.wolfssl.com/doxygen/group__Random.html#ga9a289fb3f58f4a5f7e15c2b5a1b0d7c6
         match unsafe {
             wolfssl_sys::wc_RNG_GenerateBlock(&mut self.0 as *mut _, buf.as_mut_ptr(), 8)
         } {
@@ -31,6 +47,11 @@ impl Random {
 
 impl Drop for Random {
     fn drop(&mut self) {
+        // SAFETY:
+        // [`wc_FreeRng()`][0] receives properly initialised random number generator [`WC_RNG`] as input to securely free drgb.
+        // The pointer used as argument is created by `wc_InitRng` api call in new() constructor.
+        //
+        // [0]: https://www.wolfssl.com/doxygen/group__Random.html#ga72ffd8b507b3a895af8a6e9996caba86
         let res = unsafe { wolfssl_sys::wc_FreeRng(&mut self.0 as *mut _) };
 
         if res != 0 {

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::undocumented_unsafe_blocks)]
 use crate::error::{Error, Result};
 
 /// Provides a way to extract random values from WolfSSL.

--- a/src/ssl.rs
+++ b/src/ssl.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 use crate::{
     callback::{IOCallbackResult, IOCallbacks},
     context::Context,


### PR DESCRIPTION
**Code changes:**
- Enable clippy undocumented_unsafe_blocks lint in CI
- As first step, add `#[allow(undocumented_unsafe_blocks)]` for all unsafe code
- Added safety comments for following files:
   - lib.rs
   - context.rs
   - error.rs
   - rng.rs
   -  ssl.rs

**Note:**
There are two block left without SAFETY comments in `wolf_init` and `wolf_cleanup`   for now
Will fix up in followup pr