### PR TITLE
Implement `Sync` on `ContextPointer` (so `Context` becomes `Sync`)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -285,6 +285,13 @@ impl std::ops::Deref for ContextPointer {
 // [Library Design]: https://www.wolfssl.com/documentation/manuals/wolfssl/chapter09.html
 unsafe impl Send for ContextPointer {}
 
+// SAFETY: Per documentation quoted for `Send` above: once built the
+// underlying `WOLFSSL_CONTEXT` is considered read-only. Our
+// `ContextBuilder` enforces that the `Context` is completely built
+// before a `Context` can be obtained and there are no mutable APIs on
+// `Context` object once it is built.
+unsafe impl Sync for ContextPointer {}
+
 /// A wrapper around a `WOLFSSL_CTX`.
 pub struct Context {
     protocol: Protocol,

--- a/src/context.rs
+++ b/src/context.rs
@@ -279,7 +279,7 @@ impl std::ops::Deref for ContextPointer {
 //
 // The required syncronization when setting up the context is handled
 // by the fact that [`ContextBuilder`] is not `Send`. In addition
-// neither [`WolfSslContext`] nor [`Context`] have any methods which
+// neither [`ContextPointer`] nor [`Context`] have any methods which
 // offer writeable access.
 //
 // [Library Design]: https://www.wolfssl.com/documentation/manuals/wolfssl/chapter09.html


### PR DESCRIPTION
Previously 6bc441700598 ("Mark `NonNull<wolfssl_sys::WOLFSSL>` and
`WOLFSSL_CTX` as`Send`") noted that we went further than required by WolfSSL in
our use of a `Mutex` here.

However 84af20b29214 ("Remove `Mutex` from around `Context::ctx`") then
immediately removed that `Mutex`, resulting in `Context` no longer being
`Sync`!

Per the WolfSSL documentation it appears to be safe to use a
`wolfssl_sys::WOLFSSL_CTX` from multiple threads so long as it is used
read-only. We already have protections in place to ensure this.
