### PR TITLE
 CI: Run `cargo fmt` in CI, fail if things differ

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,17 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build crate
         run: earthly --ci +build-release
+  fmt:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.7.15
+      - uses: actions/checkout@v3
+      - name: Check code formatting
+        run: earthly --ci +fmt
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Earthfile
+++ b/Earthfile
@@ -42,6 +42,10 @@ lint:
     RUN rustup component add clippy
     RUN cargo clippy --all-features --all-targets -- -D warnings
 
+fmt:
+    FROM +copy-src
+    RUN rustup component add rustfmt
+    RUN cargo fmt --check
 
 check-license:
     RUN cargo install --locked cargo-deny


### PR DESCRIPTION
[example failed run](https://github.com/expressvpn/wolfssl/actions/runs/6157850304/job/16709457229?pr=26).