### PR TITLE
Add github meta job which depends on all jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,13 @@ on:
   pull_request: null # target every PR
 
 jobs:
+  ci:
+    needs: [test, build, fmt, lint, cargo-deny]
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          echo "Build success"
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description

Added a new github meta job which depends on all other jobs

### Motivation and Context

Currently we need to specify all the required jobs in CI workflow as required checks in branch protection rule.
Having a meta job which depends on all other jobs reduce this dependency.

And we can use this meta job as required checks in branch protection rules.