### PR TITLE
Remove `wolf_init` from public view and remove `wolf_cleanup` entirely

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -451,7 +451,7 @@ impl Drop for Context {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{wolf_cleanup, wolf_init};
+    use crate::wolf_init;
     use test_case::test_case;
 
     #[test_case(Protocol::DtlsClient)]
@@ -467,13 +467,12 @@ mod tests {
     fn wolfssl_context_new(protocol: Protocol) {
         wolf_init().unwrap();
         let _ = protocol.into_method_ptr().unwrap();
-        wolf_cleanup().unwrap();
     }
 
     #[test]
     fn new() {
+        wolf_init().unwrap();
         ContextBuilder::new(Protocol::DtlsClient).unwrap();
-        wolf_cleanup().unwrap();
     }
 
     #[test]
@@ -489,8 +488,6 @@ mod tests {
             .unwrap()
             .with_root_certificate(cert)
             .unwrap();
-
-        wolf_cleanup().unwrap();
     }
 
     #[test]
@@ -501,8 +498,6 @@ mod tests {
             // we built wolfssl with.
             .with_cipher_list("TLS13-CHACHA20-POLY1305-SHA256")
             .unwrap();
-
-        wolf_cleanup().unwrap();
     }
 
     #[test]
@@ -518,8 +513,6 @@ mod tests {
             .unwrap()
             .with_certificate(cert)
             .unwrap();
-
-        wolf_cleanup().unwrap();
     }
 
     #[test]
@@ -535,8 +528,6 @@ mod tests {
             .unwrap()
             .with_private_key(key)
             .unwrap();
-
-        wolf_cleanup().unwrap();
     }
 
     #[test]
@@ -545,8 +536,6 @@ mod tests {
             .unwrap()
             .with_secure_renegotiation()
             .unwrap();
-
-        wolf_cleanup().unwrap();
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,6 +17,10 @@ pub struct ContextBuilder {
 /// Error creating a [`ContextBuilder`] object.
 #[derive(Error, Debug)]
 pub enum NewContextBuilderError {
+    /// Failed to initialize WolfSSL
+    #[error("Failed to initialize WolfSSL: {0}")]
+    InitFailed(Error),
+
     /// Failed to turn `Protocol` into a `wolfssl_sys::WOLFSSL_METHOD`
     #[error("Failed to obtain WOLFSSL_METHOD")]
     MethodFailed,
@@ -31,6 +35,8 @@ impl ContextBuilder {
     ///
     /// [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Setup.html#function-wolfssl_ctx_new
     pub fn new(protocol: Protocol) -> std::result::Result<Self, NewContextBuilderError> {
+        crate::wolf_init().map_err(NewContextBuilderError::InitFailed)?;
+
         let method_fn = protocol
             .into_method_ptr()
             .ok_or(NewContextBuilderError::MethodFailed)?;
@@ -451,7 +457,6 @@ impl Drop for Context {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::wolf_init;
     use test_case::test_case;
 
     #[test_case(Protocol::DtlsClient)]
@@ -465,13 +470,12 @@ mod tests {
     #[test_case(Protocol::TlsServerV1_2)]
     #[test_case(Protocol::TlsServerV1_3)]
     fn wolfssl_context_new(protocol: Protocol) {
-        wolf_init().unwrap();
+        crate::wolf_init().unwrap();
         let _ = protocol.into_method_ptr().unwrap();
     }
 
     #[test]
     fn new() {
-        wolf_init().unwrap();
         ContextBuilder::new(Protocol::DtlsClient).unwrap();
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ pub enum Poll<T> {
     AppData(Bytes),
 }
 
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug)]
 /// The failure result of an operation.
 pub enum Error {
     /// During secure renegotiation, if application data is found, we must call
@@ -41,7 +41,7 @@ impl Error {
 }
 
 /// Extracts an error message given a wolfssl error enum.
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug)]
 #[error("code: {code}, what: {what}")]
 pub struct FatalError {
     what: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,17 +45,6 @@ pub fn wolf_init() -> Result<()> {
     }
 }
 
-/// Wraps [`wolfSSL_Cleanup`][0]
-///
-/// [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__TLS.html#function-wolfssl_cleanup
-pub fn wolf_cleanup() -> Result<()> {
-    #[allow(clippy::undocumented_unsafe_blocks)]
-    match unsafe { wolfssl_sys::wolfSSL_Cleanup() } {
-        wolfssl_sys::WOLFSSL_SUCCESS => Ok(()),
-        e => Err(Error::fatal(e)),
-    }
-}
-
 /// Wraps [`wolfSSL_Debugging_ON`][0] and [`wolfSSL_Debugging_OFF`][1]
 ///
 /// [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Debug.html#function-wolfssl_debugging_on
@@ -181,10 +170,5 @@ mod tests {
     #[test]
     fn wolf_init_test() {
         wolf_init().unwrap();
-    }
-
-    #[test]
-    fn wolf_cleanup_test() {
-        wolf_cleanup().unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,21 @@ const TLS_MAX_RECORD_SIZE: usize = 2usize.pow(14) + 1;
 ///
 /// [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__TLS.html#function-wolfssl_init
 pub fn wolf_init() -> Result<()> {
-    #[allow(clippy::undocumented_unsafe_blocks)]
-    match unsafe { wolfssl_sys::wolfSSL_Init() } {
-        wolfssl_sys::WOLFSSL_SUCCESS => Ok(()),
-        e => Err(Error::fatal(e)),
-    }
+    static ONCE: std::sync::OnceLock<Result<()>> = std::sync::OnceLock::new();
+
+    ONCE.get_or_init(|| {
+        // SAFETY: [`wolfSSL_Init`][0] ([also][1]) must be called once
+        // per application, this is enforced using the `ONCE:
+        // OnceLock`.
+        //
+        // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__TLS.html#function-wolfssl_init
+        // [1]: https://www.wolfssl.com/doxygen/group__TLS.html#ga789ef74e34df659a62f06da2ea709737
+        match unsafe { wolfssl_sys::wolfSSL_Init() } {
+            wolfssl_sys::WOLFSSL_SUCCESS => Ok(()),
+            e => Err(Error::fatal(e)),
+        }
+    })
+    .clone()
 }
 
 /// Wraps [`wolfSSL_Debugging_ON`][0] and [`wolfSSL_Debugging_OFF`][1]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -6,6 +6,8 @@ pub struct Random(wolfssl_sys::WC_RNG);
 impl Random {
     /// Initializes a [`Random`] object.
     pub fn new() -> Result<Random> {
+        crate::wolf_init()?;
+
         let mut rng = std::mem::MaybeUninit::<wolfssl_sys::WC_RNG>::uninit();
         // SAFETY:
         // [`wc_InitRng()`][0] ([also][1]) is documented to receive [`WC_RNG`] as input to initialise seed and key cipher.


### PR DESCRIPTION
As discussed in https://github.com/expressvpn/wolfssl/pull/24#discussion_r1322705812 https://github.com/expressvpn/wolfssl/pull/24#discussion_r1322685417 these put safety were putting safety requirements into the responsibility of the caller.

For `wolf_init` push the responsibility for calling this into this crate so we can be sure we meet the "before any other call to the library" requirement from [the documentation](https://www.wolfssl.com/doxygen/group__TLS.html#ga789ef74e34df659a62f06da2ea709737). The places where we need to do the initialization are few in number and none are in hot paths -- I think it unlikely that there would ever be a hot path which didn't require some cold path setup first so I think we aren't making a rod for our own back by taking on this responsibility, although we will have to be careful to remember to add calls to `wolf_init` as we add new top-level entry points.

We then use a [`std::sync::OnceLock`](https://doc.rust-lang.org/std/sync/struct.OnceLock.html) to meet the "must be called once per application" requirement (this might be too strict, the docs don't say "at most once", but note that a second unsuccessful call to `wolfSSL_Init` would undo a prior success though!).

Since we have no use case for `wolf_cleanup` currently simply remove it so we don't have to reason about when/how it would be ok to call.