### PR TITLE
Allow access to the `IOCB` within a `Session<IOCB>`

### DIFF
--- a/src/ssl.rs
+++ b/src/ssl.rs
@@ -246,6 +246,16 @@ impl<IOCB: IOCallbacks> Session<IOCB> {
         }
     }
 
+    /// Get a reference to the IOCB embedded in this session
+    pub fn io_cb(&self) -> &IOCB {
+        self.io.as_ref()
+    }
+
+    /// Get a mutable reference to the IOCB embedded in this session
+    pub fn io_cb_mut(&mut self) -> &mut IOCB {
+        self.io.as_mut()
+    }
+
     /// Invokes [`wolfSSL_negotiate`][0] *once*.
     ///
     /// The distinction is important because it takes more than one invocation


### PR DESCRIPTION
... useful for applications which wish to update some state in their adapter without going for `Arc` etc to retain a handle.

The `IOCB` is exposed to FFI since it is used as the WolfSSL IO callback target. Therefore it is worth thinking about the safety constrains a little even though there is no `unsafe` here, particularly around `io_cb_mut`: WolfSSL is completely inert unless application code calls into it (i.e. it has no threads etc of its own). So the only way any C code can be active (and therefore potentially accessing the `IOCB` type) is if something is currently calling one of the methods on the `Sesssion` object. Since `io_cb_mut` takes a `&mut self` we therefore know that no other thread can be calling through to C code while such a reference is live, therefore it is safe to offer mutable access to the `IOCB` instance. For `io_cb`, which takes a shared ref, we cannot know if some other thread also has a shared ref, but we do know that the methods of `IOCallbacks` only accept `&self` (no `&mut self`) so there is no possibility of concurrent modification.